### PR TITLE
Add config parameter to initialize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The `initialize()` function returns a promise that resolves when the Launch Dark
 
 The user `key` is the only required attribute, see the [Launch Darkly documentation](https://docs.launchdarkly.com/docs/js-sdk-reference#section-users) for the other attributes you can provide.
 
+The `initialize()` function accepts a second parameter which is **optional**. It allows to configure the Launch Darkly client, see the [Launch Darkly documentation](https://docs.launchdarkly.com/sdk/client-side/javascript#customizing-your-client) to learn more about available options and default values.
+
 ```js
 // /app/application/route.js
 
@@ -118,12 +120,18 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model() {
-    let user = {
+    const user = {
       key: 'aa0ceb',
       anonymous: true
     };
 
-    return this.launchDarkly.initialize(user);
+    // Optional
+    const config = {
+      allAttributesPrivate: true,
+      sendEvents: false
+    };
+
+    return this.launchDarkly.initialize(user, config);
   }
 });
 ```

--- a/addon/services/launch-darkly-client-remote.js
+++ b/addon/services/launch-darkly-client-remote.js
@@ -15,7 +15,7 @@ export default Service.extend(Evented, {
     this._super(...arguments);
   },
 
-  initialize(user = {}) {
+  initialize(user = {}, configOptions) {
     let { clientSideId, streaming = false } = this._config();
 
     assert('ENV.launchDarkly.clientSideId must be specified in config/environment.js', clientSideId);
@@ -46,7 +46,7 @@ export default Service.extend(Evented, {
       return RSVP.resolve();
     }
 
-    return this._initialize(clientSideId, user, streaming);
+    return this._initialize(clientSideId, user, streaming, configOptions);
   },
 
   identify(user) {
@@ -67,9 +67,9 @@ export default Service.extend(Evented, {
     return appConfig.launchDarkly || {};
   },
 
-  _initialize(id, user, streamingOptions) {
+  _initialize(id, user, streamingOptions, configOptions) {
     return new RSVP.Promise((resolve, reject) => {
-      let client = window.LDClient.initialize(id, user);
+      let client = window.LDClient.initialize(id, user, configOptions);
 
       client.on('ready', () => {
         this.set('_client', client);


### PR DESCRIPTION
Hello :wave:

Thanks for your work on the addon. We gave LaunchDarkly a try recently and this addon saved us a lot of time!

The initial rationale behind this PR is that LaunchDarkly seems to trigger non blocking errors when the user is bouncing but they are coming up in Sentry
```
NetworkError: Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'https://events.launchdarkly.com/xxxxxxxx': Synchronous XHR in page dismissal. See https://www.chromestatus.com/feature/4664843055398912 for more details.
```
Since we're not using the event feature, I wanted to disable it and see if it could disable the `sendEvent` config option but this wasn't implemented yet 😄 

Link to the issue I'm describing: https://github.com/launchdarkly/js-client-sdk/issues/147
Link to the issue that existed in the repo about the config parameter: https://github.com/ember-launch-darkly/ember-launch-darkly/issues/60

Let me know if there is something else, I could do!
Thanks!