### PR TITLE
Fix variation resolver after bootstrapped initialisation

### DIFF
--- a/addon/-sdk/variation.js
+++ b/addon/-sdk/variation.js
@@ -4,7 +4,7 @@ export function variation(key, defaultValue = null) {
   let context = getCurrentContext();
 
   if (!context.isLocal) {
-    context.client.variation(key);
+    return context.client.variation(key);
   }
 
   return context.get(key, defaultValue);


### PR DESCRIPTION
- after initialisation the `variation` method is never returning the LD server version of the flag but always returns the one that it was bootstrapped with
- after calling `identify` everything seams to be correct because the FFs in the context are replaced with the ones retrieved from the LD servers