### PR TITLE
📦 Remove extra `ember-auto-import` devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "broccoli-merge-trees": "^4.2.0",
     "browserslist": "^4.14.7",
     "concurrently": "^5.3.0",
-    "ember-auto-import": "^1.6.0",
     "ember-cli": "~3.22.0",
     "ember-cli-babili": "^0.2.0",
     "ember-cli-dependency-checker": "^3.2.0",


### PR DESCRIPTION
ember-auto-import is both in dependencies & devDependencies

See here in dependencies https://github.com/adopted-ember-addons/ember-launch-darkly/blob/master/package.json#L26

And in devDependencies https://github.com/adopted-ember-addons/ember-launch-darkly/blob/master/package.json#L44

Resolves https://github.com/adopted-ember-addons/ember-launch-darkly/issues/320