### PR TITLE
use correct uppercase NODE_VERSION env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The github actions setup-node action does not use the correct uppercase env variable for the node version, hence the pipeline defaulting to 16 which causes it to fail: https://github.com/adopted-ember-addons/ember-launch-darkly/actions/runs/3436086560/jobs/5731693356#step:5:9