### PR TITLE
add dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"
+  open-pull-requests-limit: 15
+  labels:
+  - dependencies
+  versioning-strategy: increase


### PR DESCRIPTION
This will allow us to interact directly with [the updated dependabot](https://github.blog/2021-04-29-goodbye-dependabot-preview-hello-dependabot/) so we use commands like `@dependabot rebase`