### PR TITLE
Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 
 env:
-  NODE_VERSION: 10
+  NODE_VERSION: 12
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "release-it-lerna-changelog": "^3.1.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">= 12"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
It seems that multiple dependencies are requiring node 12 as a minimum. Upgrading to node 16 seems to be causing other issues so let's do this incrementally and use node 12 for the ci for now