### PR TITLE
Update variation.js

### DIFF
--- a/ember-launch-darkly/src/-sdk/variation.js
+++ b/ember-launch-darkly/src/-sdk/variation.js
@@ -1,7 +1,14 @@
 import { getCurrentContext } from './context';
 
 export function variation(key, defaultValue = null) {
-  let context = getCurrentContext();
+  let context;
+ 
+  try {
+    context = getCurrentContext();
+  } catch (e) {
+    // we're not initialized for some reason, just return the default val
+    return defaultValue;
+  }
 
   if (!context.isLocal) {
     context.client.variation(key);


### PR DESCRIPTION
We have cases during test runs where some modules are nested and for some unknown reason `setupLaunchDarkly` hook has not finished initializing. We have this workaround that seems to work. I would love some feedback if this workaround makes sense