### PR TITLE
fix: make sure renderers are settled before tearing down the context

### DIFF
--- a/ember-launch-darkly/src/test-support/setup-launch-darkly.js
+++ b/ember-launch-darkly/src/test-support/setup-launch-darkly.js
@@ -40,7 +40,8 @@ export default function setupLaunchDarkly(hooks) {
     };
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(async function () {
+    await settled();
     delete this.withVariation;
     removeCurrentContext();
   });


### PR DESCRIPTION
We have been running into an issue where when we use js variant helper, tests would throw an error about uninitialized LD at the end of every test. This fix would make sure all renderers are settled before removing context.