### PR TITLE
Documentation: LaunchDarkly initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ export default class ApplicationRoute extends Route {
       key: 'aa0ceb',
     };
 
-    let { clientSideId, ...rest } = config;
+    let { launchDarkly: { clientSideId }, ...rest } = config;
 
     return await initialize(clientSideId, user, rest);
   }


### PR DESCRIPTION
Given that `clientSideId` is a nested property inside `launchDarkly`, we need to update the destructure to access the nested property.