### PR TITLE
Make tracked-built-ins a peerDep

### DIFF
--- a/ember-launch-darkly/package.json
+++ b/ember-launch-darkly/package.json
@@ -63,6 +63,7 @@
     "prettier-plugin-ember-template-tag": "^2.0.4",
     "rollup": "^4.39.0",
     "rollup-plugin-copy": "^3.5.0",
+    "tracked-built-ins": "^4.0.0",
     "webpack": "^5.98.0"
   },
   "peerDependencies": {

--- a/ember-launch-darkly/package.json
+++ b/ember-launch-darkly/package.json
@@ -40,8 +40,7 @@
     "@embroider/addon-shim": "^1.8.9",
     "decorator-transforms": "^2.2.2",
     "ember-window-mock": "^1.0.2",
-    "launchdarkly-js-client-sdk": "^3.1.1",
-    "tracked-built-ins": "^4.0.0"
+    "launchdarkly-js-client-sdk": "^3.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -67,7 +66,8 @@
     "webpack": "^5.98.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 4.12.0"
+    "ember-source": ">= 4.12.0",
+    "tracked-built-ins": ">= 3.4.0"
   },
   "ember": {
     "edition": "octane"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       launchdarkly-js-client-sdk:
         specifier: ^3.1.1
         version: 3.5.0
-      tracked-built-ins:
-        specifier: ^4.0.0
-        version: 4.0.0(@babel/core@7.26.10)
     devDependencies:
       '@babel/core':
         specifier: ^7.25.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       rollup-plugin-copy:
         specifier: ^3.5.0
         version: 3.5.0
+      tracked-built-ins:
+        specifier: ^4.0.0
+        version: 4.0.0(@babel/core@7.26.10)
       webpack:
         specifier: ^5.98.0
         version: 5.98.0


### PR DESCRIPTION
I'm marking this a breaking because you need to install tracked-built-ins in your app now.